### PR TITLE
Feature/residual bootstrap tree

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Formats data from .yaml files, calculates information for each inte
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Suggests: 
     knitr,
     missForest,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # ScrambledTreeBuilder dev
 
 * Fix diagonal values in `Halo_PercentDiff`.
+* Fix detection of YAML files.
 
 # ScrambledTreeBuilder 1.1.0
 

--- a/R/ConvenientTblTree.R
+++ b/R/ConvenientTblTree.R
@@ -19,6 +19,13 @@ method(labelOrder, ConvenientTblTree) <- function (tree) {
   order(treeTips$y, decreasing = TRUE)
 }
 
+labelOrderedNames <- new_generic("labelOrderedNames", "tree")
+
+method(labelOrderedNames, ConvenientTblTree) <- function (tree) {
+  o <- labelOrder(tree)
+  tree$label[o]
+}
+
 #' Order a comparison matrix
 #'
 #' Re-order a comparison matrix according to the leaves of a plotted tree,
@@ -39,7 +46,7 @@ method(labelOrder, ConvenientTblTree) <- function (tree) {
 orderWithTree <- new_generic("orderWithTree", c("m", "tree"), function (m, tree) S7_dispatch()) # Needed so that `...` is not a parameter
 
 method(orderWithTree, list(class_any, ConvenientTblTree)) <- function (m, tree) {
-  o <- labelOrder(tree)
+  o <- labelOrderedNames(tree)
   m[o,o]
 }
 

--- a/R/resultFiles.R
+++ b/R/resultFiles.R
@@ -26,7 +26,7 @@
 #' @export
 
 resultFiles <- function (dir, remove = "removedAssemblies.txt") {
-    files <- list.files(dir, pattern = "*.yaml*", full.names = TRUE)
+    files <- list.files(dir, pattern = ".yaml$|.yaml.bz2$|.yaml.gz$|.yaml.gz$", full.names = TRUE)
     names <- basename(files) |>
       sub(pattern = ".gz|.bz2|.xz", replacement = "") |>
       sub(pattern = ".yaml",        replacement = "")


### PR DESCRIPTION
This PR adds a new exported function `residualBootstrapTree()` that performs
residual-resampling bootstrap on a distance matrix and maps clade support
onto a reference tree.